### PR TITLE
Fix package manager detection logic

### DIFF
--- a/src/segments/node.go
+++ b/src/segments/node.go
@@ -101,7 +101,7 @@ func (n *Node) loadContext() {
 		if n.env.HasFiles(pm.fileName) {
 			n.PackageManagerName = pm.name
 			n.PackageManagerIcon = n.props.GetString(pm.iconProperty, pm.defaultIcon)
-			return
+			break
 		}
 	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Replace return with break after identifying the package manager to ensure the rest of the context loading proceeds correctly.