### PR TITLE
docs(node): add bun package manager

### DIFF
--- a/website/docs/segments/languages/node.mdx
+++ b/website/docs/segments/languages/node.mdx
@@ -37,6 +37,7 @@ import Config from "@site/src/components/Config.js";
 | `pnpm_icon`             |  `string`  |                                  `\uF02C1`                                   | the icon/text to display when using PNPM                                                                                                                                                                                             |
 | `yarn_icon`             |  `string`  |                                  `\uF011B`                                   | the icon/text to display when using Yarn                                                                                                                                                                                             |
 | `npm_icon`              |  `string`  |                                   `\uE71E`                                   | the icon/text to display when using NPM                                                                                                                                                                                              |
+| `bun_icon`              |  `string`  |                                   `\ue76f`                                   | the icon/text to display when using Bun                                                                                                                                                                                              |
 | `extensions`            | `[]string` | `*.js, *.ts, package.json, .nvmrc, pnpm-workspace.yaml, .pnpmfile.cjs, .vue` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`               | `[]string` |                                                                              | allows to override the list of folder names to validate                                                                                                                                                                              |
 
@@ -52,18 +53,18 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name                  | Type      | Description                                                                                       |
-| --------------------- | --------- | ------------------------------------------------------------------------------------------------- |
-| `.Full`               | `string`  | the full version                                                                                  |
-| `.Major`              | `string`  | major number                                                                                      |
-| `.Minor`              | `string`  | minor number                                                                                      |
-| `.Patch`              | `string`  | patch number                                                                                      |
-| `.URL`                | `string`  | URL of the version info / release notes                                                           |
-| `.Error`              | `string`  | error encountered when fetching the version string                                                |
-| `.PackageManagerName` | `string`  | the package manager name (`npm`, `yarn` or `pnpm`) when setting `fetch_package_manager` to `true` |
-| `.PackageManagerIcon` | `string`  | the PNPM, Yarn, or NPM icon when setting `fetch_package_manager` to `true`                        |
-| `.Mismatch`           | `boolean` | true if the version in `.nvmrc` is not equal to `.Full`                                           |
-| `.Expected`           | `string`  | the expected version set in `.nvmrc`                                                              |
+| Name                  | Type      | Description                                                                                              |
+| --------------------- | --------- | -------------------------------------------------------------------------------------------------------- |
+| `.Full`               | `string`  | the full version                                                                                         |
+| `.Major`              | `string`  | major number                                                                                             |
+| `.Minor`              | `string`  | minor number                                                                                             |
+| `.Patch`              | `string`  | patch number                                                                                             |
+| `.URL`                | `string`  | URL of the version info / release notes                                                                  |
+| `.Error`              | `string`  | error encountered when fetching the version string                                                       |
+| `.PackageManagerName` | `string`  | the package manager name (`bun`, `npm`, `yarn` or `pnpm`) when setting `fetch_package_manager` to `true` |
+| `.PackageManagerIcon` | `string`  | the PNPM, Yarn, Bun, or NPM icon when setting `fetch_package_manager` to `true`                          |
+| `.Mismatch`           | `boolean` | true if the version in `.nvmrc` is not equal to `.Full`                                                  |
+| `.Expected`           | `string`  | the expected version set in `.nvmrc`                                                                     |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates


### PR DESCRIPTION
## Summary by Sourcery

Document Bun package manager support in the Node segment by adding `bun_icon` and updating version metadata to include Bun.

Documentation:
- Add `bun_icon` configuration option for Bun in Node documentation.
- Include Bun in the list of supported package managers for `.PackageManagerName` and `.PackageManagerIcon`.