### PR TITLE
feat(docker): add `compose.y(a)ml` to default extensions

### DIFF
--- a/src/segments/docker.go
+++ b/src/segments/docker.go
@@ -47,6 +47,8 @@ func (d *Docker) configFiles() []string {
 
 func (d *Docker) Enabled() bool {
 	extensions := []string{
+		"compose.yml",
+		"compose.yaml",
 		"docker-compose.yml",
 		"docker-compose.yaml",
 		"Dockerfile",

--- a/src/segments/docker_test.go
+++ b/src/segments/docker_test.go
@@ -66,6 +66,8 @@ func TestDockerFiles(t *testing.T) {
 		ExpectedEnabled bool
 		HasFiles        bool
 	}{
+		{Case: "compose.yml", ExpectedEnabled: true, HasFiles: true},
+		{Case: "compose.yaml", ExpectedEnabled: true, HasFiles: true},
 		{Case: "docker-compose.yml", ExpectedEnabled: true, HasFiles: true},
 		{Case: "docker-compose.yaml", ExpectedEnabled: true, HasFiles: true},
 		{Case: "Dockerfile", ExpectedEnabled: true, HasFiles: true},

--- a/website/docs/segments/cli/docker.mdx
+++ b/website/docs/segments/cli/docker.mdx
@@ -25,11 +25,11 @@ import Config from "@site/src/components/Config.js";
 
 ## Properties
 
-| Name            |    Type    |                        Default                        | Description                                                                                                                                                              |
-| --------------- | :--------: | :---------------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `display_mode`  |  `string`  |                       `context`                       | <ul><li>`files`: the segment is only displayed when a file `extensions` listed is present</li><li>`context`: displays the segment when a Docker context active</li></ul> |
-| `fetch_context` | `boolean`  |                        `true`                         | also fetch the current active Docker context when in the `files` display mode                                                                                            |
-| `extensions`    | `[]string` | `docker-compose.yml, docker-compose.yaml, Dockerfile` | allows to override the default list of file extensions to validate                                                                                                       |
+| Name            |    Type    |                                      Default                                     | Description                                                                                                                                                              |
+| --------------- | :--------: | :------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `display_mode`  |  `string`  |                                     `context`                                    | <ul><li>`files`: the segment is only displayed when a file `extensions` listed is present</li><li>`context`: displays the segment when a Docker context active</li></ul> |
+| `fetch_context` | `boolean`  |                                      `true`                                      | also fetch the current active Docker context when in the `files` display mode                                                                                            |
+| `extensions`    | `[]string` | `compose.yml, compose.yaml, docker-compose.yml, docker-compose.yaml, Dockerfile` | allows to override the default list of file extensions to validate                                                                                                       |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for compose.yml and compose.yaml in the Docker segment by including them in the default extensions list and reflecting these changes in tests and documentation.

New Features:
- Detect compose.yml and compose.yaml as valid Docker compose files in the Docker segment

Documentation:
- Update Docker segment documentation to list compose.yml and compose.yaml among default extensions

Tests:
- Add unit tests to verify Docker segment activation for compose.yml and compose.yaml