### PR TITLE
docs: fix readme docusaurus 2 ref

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # Website
 
-This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
 ## Installation
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fix website README to refer to Docusaurus generally instead of Docusaurus 2 and update the link to the main site